### PR TITLE
[MS-207] Loading ProjectID & ModuleID dynamic attributes to use in TEI profiles

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,4 +90,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.repository_name }} - Android APK
-          path: ${{ env.main_project_module }}/build/outputs/apk/dhis/debug/dhis2-v${{ steps.read-version.outputs.vName }}-dhis-debug.apk
+          path: ${{ env.main_project_module }}/build/outputs/apk/dhis/debug/simtracker-dhis2-v${{ steps.read-version.outputs.vName }}-dhis-debug.apk

--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
-# README #
+# SimTracker
 
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=dhis2_dhis2-android-capture-app&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=dhis2_dhis2-android-capture-app)
-[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=dhis2_dhis2-android-capture-app&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=dhis2_dhis2-android-capture-app)
+A fork of the [DHIS2 Android app](https://github.com/dhis2/dhis2-android-capture-app).
 
-Check the [Wiki](https://github.com/dhis2/dhis2-android-capture-app/wiki) for information about how to build the project and its architecture **(WIP)**
+## Differences from the upstream
 
-### What is this repository for? ###
+The features below may be in a prototype stage.
 
-DHIS2 Android application.
+### Loading ProjectID & ModuleID dynamic (custom) attributes to use in TEI (beneficiary) profiles
+
+SimTracker is intended to connect to Simprints ID, so the data models shared between the two apps are conceptually related, approximately the following way:
+
+| Concept \ App                                   | SimTracker (DHIS2) | Simprints ID |
+|-------------------------------------------------|--------------------|--------------|
+| A healthcare solution beneficiaries enroll into | Program            | Project      |
+| Geographical area or a healthcare facility      | Organisation Unit  | Module       |
+
+#### Support for a `ProjectID` text input field as a dynamic attribute of a Program
+
+* In a DHIS2 instance admin web UI, `ProjectID` can be added though `Menu` -> `Maintenance` -> `Other` -> `Attribute`: add a text-value attribute named `ProjectID`, make it apply to the `Program` object.
+* To edit or verify that the `ProjectID` custom attribute is available in Programs, see `Menu` -> `Maintenance` -> `Program` -> `Program`: the `ProjectID` input field should be visible for existing or new Programs.
+* SimTracker, connected to the same DHIS2 instance, will download and internally store the up-to-date `ProgramUid`-to-`ProjectID` key-value mappings when the sync is performed, for the Programs where the `ProjectID` dynamic attribute value is defined (isn't blank).
+* When viewing a profile of a TEI enrolled into a Program for which a `ProjectID` is defined, the value of the `ProjectID` will be displayed.
+
+#### Support for a `ModuleID` text input field as a dynamic attribute of an Organisation Unit
+
+* In a DHIS2 instance admin web UI, `ModuleID` can be added though `Menu` -> `Maintenance` -> `Other` -> `Attribute`: add a text-value attribute named `ModuleID`, make it apply to the `Organisation unit` object.
+* To edit or verify that the `ModuleID` custom attribute is available in Organisation Units, see `Menu` -> `Maintenance` -> `Organisation unit` -> `Organisation unit`: the `ModuleID` input field should be visible for existing or new Organisation Units.
+* SimTracker, connected to the same DHIS2 instance, will download and internally store the up-to-date `OrganisationUnitUid`-to-`ModuleID` key-value mappings when the sync is performed, for the Organisation Units where the `ModuleID` dynamic attribute value is defined (isn't blank).
+* When viewing a profile of a TEI belonging to an Organisation Unit for which a `ModuleID` is defined, the value of the `ModuleID` will be displayed.
+* If `ModuleID` isn't defined for the TEI's exact Organisation Unit, but is defined for an upper level Organisation Unit, the upper level one's `ModuleID` will be used instead. If Organisation Units on multiple upper levels have `ModuleID`, the lowest level one will be used.
+
+### Automated fork sync with the upstream
+
+A [sync-from-upstream](https://github.com/Simprints/SimTracker/blob/main/.github/workflows/sync-from-upstream.yml) GitHub Action periodically creates a pull request to merge the changes in the upstream to this fork.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -204,6 +204,10 @@ android {
         }
     }
 
+    base {
+        archivesName.set("simtracker-dhis2-v" + libs.versions.vName.get())
+    }
+
     kotlinOptions {
         jvmTarget = "17"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -232,6 +232,7 @@ dependencies {
     implementation(project(":stock-usecase"))
 
     implementation(libs.security.conscrypt)
+    implementation(libs.security.crypto)
     implementation(libs.security.rootbeer)
     implementation(libs.security.openId)
     implementation(libs.kotlin.serialization.json)

--- a/app/src/main/java/org/dhis2/data/service/ReservedValuesWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/ReservedValuesWorkerModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
 
@@ -33,6 +34,7 @@ class ReservedValuesWorkerModule {
         analyticsHelper: AnalyticsHelper,
         syncStatusController: SyncStatusController,
         syncRepository: SyncRepository,
+        downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase,
     ): SyncPresenter {
         return SyncPresenterImpl(
             d2,
@@ -41,6 +43,7 @@ class ReservedValuesWorkerModule {
             analyticsHelper,
             syncStatusController,
             syncRepository,
+            downloadSimprintsIdAttributesUseCase,
         )
     }
 }

--- a/app/src/main/java/org/dhis2/data/service/SyncDataWorker.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncDataWorker.java
@@ -64,8 +64,19 @@ public class SyncDataWorker extends Worker {
         boolean isEventOk = true;
         boolean isTeiOk = true;
         boolean isDataValue = true;
+        boolean isSimprintsIdAttributesOk = true;
 
         long init = System.currentTimeMillis();
+
+        try {
+            presenter.downloadSimprintsIdAttributes();
+        } catch (Exception e) {
+            if (!new NetworkUtils(getApplicationContext()).isOnline()) {
+                presenter.setNetworkUnavailable();
+            }
+            Timber.e(e);
+            isSimprintsIdAttributesOk = false;
+        }
 
         triggerNotification(
                 getApplicationContext().getString(R.string.app_name),
@@ -134,7 +145,7 @@ public class SyncDataWorker extends Worker {
         SyncResult syncResult = presenter.checkSyncStatus();
 
         prefs.setValue(Constants.LAST_DATA_SYNC, lastDataSyncDate);
-        prefs.setValue(Constants.LAST_DATA_SYNC_STATUS, isEventOk && isTeiOk && isDataValue && syncResult == SyncResult.SYNC);
+        prefs.setValue(Constants.LAST_DATA_SYNC_STATUS, isEventOk && isTeiOk && isDataValue && isSimprintsIdAttributesOk && syncResult == SyncResult.SYNC);
         prefs.setValue(Constants.SYNC_RESULT, syncResult.name());
 
         cancelNotification();

--- a/app/src/main/java/org/dhis2/data/service/SyncDataWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncDataWorkerModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
 
@@ -25,6 +26,7 @@ class SyncDataWorkerModule {
         analyticsHelper: AnalyticsHelper,
         syncStatusController: SyncStatusController,
         syncRepository: SyncRepository,
+        downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase,
     ): SyncPresenter {
         return SyncPresenterImpl(
             d2,
@@ -33,6 +35,7 @@ class SyncDataWorkerModule {
             analyticsHelper,
             syncStatusController,
             syncRepository,
+            downloadSimprintsIdAttributesUseCase,
         )
     }
 }

--- a/app/src/main/java/org/dhis2/data/service/SyncGranularRxModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncGranularRxModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
 
@@ -25,6 +26,7 @@ class SyncGranularRxModule {
         analyticsHelper: AnalyticsHelper,
         syncStatusController: SyncStatusController,
         syncRepository: SyncRepository,
+        downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase,
     ): SyncPresenter {
         return SyncPresenterImpl(
             d2,
@@ -33,6 +35,7 @@ class SyncGranularRxModule {
             analyticsHelper,
             syncStatusController,
             syncRepository,
+            downloadSimprintsIdAttributesUseCase,
         )
     }
 }

--- a/app/src/main/java/org/dhis2/data/service/SyncInitWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncInitWorkerModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
 
@@ -25,6 +26,7 @@ class SyncInitWorkerModule {
         analyticsHelper: AnalyticsHelper,
         syncStatusController: SyncStatusController,
         syncRepository: SyncRepository,
+        downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase,
     ): SyncPresenter {
         return SyncPresenterImpl(
             d2,
@@ -33,6 +35,7 @@ class SyncInitWorkerModule {
             analyticsHelper,
             syncStatusController,
             syncRepository,
+            downloadSimprintsIdAttributesUseCase,
         )
     }
 }

--- a/app/src/main/java/org/dhis2/data/service/SyncMetadataWorkerModule.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncMetadataWorkerModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import org.dhis2.commons.di.dagger.PerService
 import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
 
@@ -25,6 +26,7 @@ class SyncMetadataWorkerModule {
         analyticsHelper: AnalyticsHelper,
         syncStatusController: SyncStatusController,
         syncRepository: SyncRepository,
+        downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase,
     ): SyncPresenter {
         return SyncPresenterImpl(
             d2,
@@ -33,6 +35,7 @@ class SyncMetadataWorkerModule {
             analyticsHelper,
             syncStatusController,
             syncRepository,
+            downloadSimprintsIdAttributesUseCase,
         )
     }
 }

--- a/app/src/main/java/org/dhis2/data/service/SyncPresenter.java
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenter.java
@@ -19,6 +19,8 @@ interface SyncPresenter {
 
     void syncAndDownloadDataValues() throws Exception;
 
+    void downloadSimprintsIdAttributes() throws Exception;
+
     void syncReservedValues();
 
     SyncResult checkSyncStatus();

--- a/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
+++ b/app/src/main/java/org/dhis2/data/service/SyncPresenterImpl.kt
@@ -22,6 +22,7 @@ import org.dhis2.commons.prefs.PreferenceProvider
 import org.dhis2.data.service.workManager.WorkManagerController
 import org.dhis2.data.service.workManager.WorkerItem
 import org.dhis2.data.service.workManager.WorkerType
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.DateUtils
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.dhis2.utils.analytics.matomo.DEFAULT_EXTERNAL_TRACKER_NAME
@@ -47,6 +48,7 @@ class SyncPresenterImpl(
     private val analyticsHelper: AnalyticsHelper,
     private val syncStatusController: SyncStatusController,
     private val syncRepository: SyncRepository,
+    private val downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase,
 ) : SyncPresenter {
 
     override fun initSyncControllerMap() {
@@ -195,6 +197,11 @@ class SyncPresenterImpl(
                     ),
                 ).blockingAwait()
         }
+    }
+
+    override fun downloadSimprintsIdAttributes() {
+        downloadSimprintsIdAttributesUseCase.execute()
+            .exceptionOrNull()?.let { throw it }
     }
 
     override fun syncMetadata(progressUpdate: SyncMetadataWorker.OnProgressUpdate) {

--- a/app/src/main/java/org/dhis2/data/simprintsId/local/LocalSimprintsModuleIdMappingRepository.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/local/LocalSimprintsModuleIdMappingRepository.kt
@@ -1,0 +1,31 @@
+package org.dhis2.data.simprintsId.local
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import javax.inject.Inject
+
+class LocalSimprintsModuleIdMappingRepository @Inject constructor(
+    context: Context,
+) {
+    private val securePreferences = EncryptedSharedPreferences.create(
+        context,
+        "ModuleIdMappings",
+        MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    fun updateOrgUnitUidToModuleIdMap(newMap: Map<String, String>) {
+        with(securePreferences.edit()) {
+            clear()
+            newMap.entries.forEach { (key, value) ->
+                putString(key, value)
+            }
+            apply()
+        }
+    }
+
+    fun getModuleIdOrNull(orgUnitUid: String): String? =
+        securePreferences.getString(orgUnitUid, null)
+}

--- a/app/src/main/java/org/dhis2/data/simprintsId/local/LocalSimprintsProjectIdMappingRepository.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/local/LocalSimprintsProjectIdMappingRepository.kt
@@ -1,0 +1,31 @@
+package org.dhis2.data.simprintsId.local
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import javax.inject.Inject
+
+class LocalSimprintsProjectIdMappingRepository @Inject constructor(
+    context: Context,
+) {
+    private val securePreferences = EncryptedSharedPreferences.create(
+        context,
+        "ProjectIdMappings",
+        MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+    )
+
+    fun updateProgramUidToProjectIdMap(newMap: Map<String, String>) {
+        with(securePreferences.edit()) {
+            clear()
+            newMap.entries.forEach { (key, value) ->
+                putString(key, value)
+            }
+            apply()
+        }
+    }
+
+    fun getProjectIdOrNull(programUid: String): String? =
+        securePreferences.getString(programUid, null)
+}

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsModuleIdMappingRepository.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsModuleIdMappingRepository.kt
@@ -1,0 +1,42 @@
+package org.dhis2.data.simprintsId.remote
+
+import android.annotation.SuppressLint
+import org.hisp.dhis.android.core.D2
+import javax.inject.Inject
+
+class RemoteSimprintsModuleIdMappingRepository @Inject constructor(
+    private val d2: D2,
+) {
+
+    @SuppressLint("VisibleForTests")
+    fun getOrgUnitUidToModuleIdMap(): Result<Map<String, String>> {
+        val service = d2.retrofit().create(SimprintsDataMappingApiService::class.java)
+
+        val moduleIdAttributeCall = service.getAttributes(
+            paging = false,
+            filter = "displayName:eq:ModuleID",
+        )
+        val moduleIdAttributeUid = with(moduleIdAttributeCall.execute()) {
+            takeIf { isSuccessful }?.body()
+                ?.attributes?.first()?.id
+                ?: return Result.failure(
+                    SimprintsDataMappingApiException("Attribute API: ${code()} (${message()})"),
+                )
+        }
+
+        val orgUnitsCall = service.getOrganisationUnits(
+            paging = false,
+            fields = "id,displayName,$moduleIdAttributeUid~rename(moduleId)",
+            filter = "attributeValues.attribute.id:eq:$moduleIdAttributeUid",
+        )
+        val orgUnitUidToModuleIdMap = with(orgUnitsCall.execute()) {
+            takeIf { isSuccessful }?.body()
+                ?.organisationUnits?.associate { it.id to it.moduleId }
+                ?: return Result.failure(
+                    SimprintsDataMappingApiException("OrgUnits API: ${code()} (${message()})"),
+                )
+        }
+
+        return Result.success(orgUnitUidToModuleIdMap)
+    }
+}

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsModuleIdMappingRepository.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsModuleIdMappingRepository.kt
@@ -8,12 +8,49 @@ class RemoteSimprintsModuleIdMappingRepository @Inject constructor(
     private val d2: D2,
 ) {
 
+    /*
+    Gets a map of DHIS2 Organisation Unit UIDs to Simprints Module IDs from DHIS2 API
+    with a D2-provided Retrofit HTTP client already configured with the current auth session,
+    given that a dynamic attribute named ModuleID is defined,
+    in 2 steps - example:
+    from GET /api/attributes.json?paging=false&fields=id,displayName&filter=displayName:eq:ModuleID
+    response
+    {
+        "attributes": [
+            {
+                "id": "ModuleIdAttributeUid",
+                "displayName": "ModuleID"
+            }
+        ]
+    }
+    gets "ModuleIdAttributeUid",
+    and then, using ModuleIdAttributeUid,
+    from GET /api/organisationUnits.json?paging=false&fields=id,attributeValues[attribute[id],value]&filter=attributeValues.attribute.id:eq:ModuleIdAttributeUid
+    response
+    {
+        "organisationUnits": [
+            {
+                "id": "OrganisationUnitUid",
+                "attributeValues": [
+                    {
+                        "attribute": {
+                            "id": "ModuleIdAttributeUid"
+                        },
+                        "value": "ModuleIdAttributeValue"
+                    }
+                ]
+            }
+        ]
+    }
+    gets mapOf("OrganisationUnitUid" to "ModuleIdAttributeValue")
+     */
     @SuppressLint("VisibleForTests")
     fun getOrgUnitUidToModuleIdMap(): Result<Map<String, String>> {
         val service = d2.retrofit().create(SimprintsDataMappingApiService::class.java)
 
         val moduleIdAttributeCall = service.getAttributes(
             paging = false,
+            fields = "id,displayName",
             filter = "displayName:eq:ModuleID",
         )
         val moduleIdAttributeUid = with(moduleIdAttributeCall.execute()) {
@@ -26,17 +63,18 @@ class RemoteSimprintsModuleIdMappingRepository @Inject constructor(
 
         val orgUnitsCall = service.getOrganisationUnits(
             paging = false,
-            fields = "id,displayName,$moduleIdAttributeUid~rename(moduleId)",
+            fields = "id,attributeValues[attribute[id],value]",
             filter = "attributeValues.attribute.id:eq:$moduleIdAttributeUid",
         )
-        val orgUnitUidToModuleIdMap = with(orgUnitsCall.execute()) {
-            takeIf { isSuccessful }?.body()
-                ?.organisationUnits?.associate { it.id to it.moduleId }
-                ?: return Result.failure(
-                    SimprintsDataMappingApiException("OrgUnits API: ${code()} (${message()})"),
-                )
+        val orgUnitUidToModuleIdPairs = with(orgUnitsCall.execute()) {
+            takeIf { isSuccessful }?.body()?.organisationUnits?.mapNotNull { orgUnit ->
+                orgUnit.attributeValues.find { it.attribute.id == moduleIdAttributeUid }
+                    ?.run { orgUnit.id to value }
+            } ?: return Result.failure(
+                SimprintsDataMappingApiException("OrgUnits API: ${code()} (${message()})"),
+            )
         }
 
-        return Result.success(orgUnitUidToModuleIdMap)
+        return Result.success(orgUnitUidToModuleIdPairs.toMap())
     }
 }

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsProjectIdMappingRepository.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsProjectIdMappingRepository.kt
@@ -8,12 +8,49 @@ class RemoteSimprintsProjectIdMappingRepository @Inject constructor(
     private val d2: D2,
 ) {
 
+    /*
+    Gets a map of DHIS2 Program UIDs to Simprints Project IDs from DHIS2 API
+    with a D2-provided Retrofit HTTP client already configured with the current auth session,
+    given that a dynamic attribute named ProjectID is defined,
+    in 2 steps - example:
+    from GET /api/attributes.json?paging=false&fields=id,displayName&filter=displayName:eq:ProjectID
+    response
+    {
+        "attributes": [
+            {
+                "id": "ProjectIdAttributeUid",
+                "displayName": "ProjectID"
+            }
+        ]
+    }
+    gets "ProjectIdAttributeUid",
+    and then, using ProjectIdAttributeUid,
+    from GET /api/programs.json?paging=false&fields=id,attributeValues[attribute[id],value]&filter=attributeValues.attribute.id:eq:ProjectIdAttributeUid
+    response
+    {
+        "programs": [
+            {
+                "id": "ProgramUid",
+                "attributeValues": [
+                    {
+                        "attribute": {
+                            "id": "ProjectIdAttributeUid"
+                        },
+                        "value": "ProjectIdAttributeValue"
+                    }
+                ]
+            }
+        ]
+    }
+    gets mapOf("ProgramUid" to "ProjectIdAttributeValue")
+     */
     @SuppressLint("VisibleForTests")
     fun getProgramUidToProjectIdMap(): Result<Map<String, String>> {
         val service = d2.retrofit().create(SimprintsDataMappingApiService::class.java)
 
         val projectIdAttributeCall = service.getAttributes(
             paging = false,
+            fields = "id,displayName",
             filter = "displayName:eq:ProjectID",
         )
         val projectIdAttributeUid = with(projectIdAttributeCall.execute()) {
@@ -26,17 +63,18 @@ class RemoteSimprintsProjectIdMappingRepository @Inject constructor(
 
         val programsCall = service.getPrograms(
             paging = false,
-            fields = "id,displayName,$projectIdAttributeUid~rename(projectId)",
+            fields = "id,attributeValues[attribute[id],value]",
             filter = "attributeValues.attribute.id:eq:$projectIdAttributeUid",
         )
-        val programUidToProjectIdMap = with(programsCall.execute()) {
-            takeIf { isSuccessful }?.body()
-                ?.programs?.associate { it.id to it.projectId }
-                ?: return Result.failure(
-                    SimprintsDataMappingApiException("Programs API: ${code()} (${message()})"),
-                )
+        val programUidToProjectIdPairs = with(programsCall.execute()) {
+            takeIf { isSuccessful }?.body()?.programs?.mapNotNull { program ->
+                program.attributeValues.find { it.attribute.id == projectIdAttributeUid }
+                    ?.run { program.id to value }
+            } ?: return Result.failure(
+                SimprintsDataMappingApiException("Programs API: ${code()} (${message()})"),
+            )
         }
 
-        return Result.success(programUidToProjectIdMap)
+        return Result.success(programUidToProjectIdPairs.toMap())
     }
 }

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsProjectIdMappingRepository.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/RemoteSimprintsProjectIdMappingRepository.kt
@@ -1,0 +1,42 @@
+package org.dhis2.data.simprintsId.remote
+
+import android.annotation.SuppressLint
+import org.hisp.dhis.android.core.D2
+import javax.inject.Inject
+
+class RemoteSimprintsProjectIdMappingRepository @Inject constructor(
+    private val d2: D2,
+) {
+
+    @SuppressLint("VisibleForTests")
+    fun getProgramUidToProjectIdMap(): Result<Map<String, String>> {
+        val service = d2.retrofit().create(SimprintsDataMappingApiService::class.java)
+
+        val projectIdAttributeCall = service.getAttributes(
+            paging = false,
+            filter = "displayName:eq:ProjectID",
+        )
+        val projectIdAttributeUid = with(projectIdAttributeCall.execute()) {
+            takeIf { isSuccessful }?.body()
+                ?.attributes?.first()?.id
+                ?: return Result.failure(
+                    SimprintsDataMappingApiException("Attribute API: ${code()} (${message()})"),
+                )
+        }
+
+        val programsCall = service.getPrograms(
+            paging = false,
+            fields = "id,displayName,$projectIdAttributeUid~rename(projectId)",
+            filter = "attributeValues.attribute.id:eq:$projectIdAttributeUid",
+        )
+        val programUidToProjectIdMap = with(programsCall.execute()) {
+            takeIf { isSuccessful }?.body()
+                ?.programs?.associate { it.id to it.projectId }
+                ?: return Result.failure(
+                    SimprintsDataMappingApiException("Programs API: ${code()} (${message()})"),
+                )
+        }
+
+        return Result.success(programUidToProjectIdMap)
+    }
+}

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/SimprintsDataMappingApiException.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/SimprintsDataMappingApiException.kt
@@ -1,0 +1,4 @@
+package org.dhis2.data.simprintsId.remote
+
+data class SimprintsDataMappingApiException(override val message: String) :
+    RuntimeException(message)

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/SimprintsDataMappingApiService.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/SimprintsDataMappingApiService.kt
@@ -1,0 +1,48 @@
+package org.dhis2.data.simprintsId.remote
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+internal interface SimprintsDataMappingApiService {
+
+    data class Attributes(val attributes: List<Attribute>)
+
+    data class Attribute(val displayName: String, val id: String)
+
+    data class Programs(val programs: List<Program>)
+
+    data class Program(
+        val displayName: String,
+        val id: String,
+        val projectId: String,
+    )
+
+    data class OrganisationUnits(val organisationUnits: List<OrganisationUnit>)
+
+    data class OrganisationUnit(
+        val displayName: String,
+        val id: String,
+        val moduleId: String,
+    )
+
+    @GET("/api/attributes")
+    fun getAttributes(
+        @Query("paging") paging: Boolean,
+        @Query("filter") filter: String,
+    ): Call<Attributes>
+
+    @GET("/api/programs")
+    fun getPrograms(
+        @Query("paging") paging: Boolean,
+        @Query("fields") fields: String,
+        @Query("filter") filter: String,
+    ): Call<Programs>
+
+    @GET("/api/organisationUnits")
+    fun getOrganisationUnits(
+        @Query("paging") paging: Boolean,
+        @Query("fields") fields: String,
+        @Query("filter") filter: String,
+    ): Call<OrganisationUnits>
+}

--- a/app/src/main/java/org/dhis2/data/simprintsId/remote/SimprintsDataMappingApiService.kt
+++ b/app/src/main/java/org/dhis2/data/simprintsId/remote/SimprintsDataMappingApiService.kt
@@ -12,34 +12,31 @@ internal interface SimprintsDataMappingApiService {
 
     data class Programs(val programs: List<Program>)
 
-    data class Program(
-        val displayName: String,
-        val id: String,
-        val projectId: String,
-    )
+    data class Program(val id: String, val attributeValues: List<AttributeValue>)
 
     data class OrganisationUnits(val organisationUnits: List<OrganisationUnit>)
 
-    data class OrganisationUnit(
-        val displayName: String,
-        val id: String,
-        val moduleId: String,
-    )
+    data class OrganisationUnit(val id: String, val attributeValues: List<AttributeValue>)
 
-    @GET("/api/attributes")
+    data class AttributeValue(val attribute: AttributeID, val value: String)
+
+    data class AttributeID(val id: String)
+
+    @GET("/api/attributes.json")
     fun getAttributes(
         @Query("paging") paging: Boolean,
+        @Query("fields") fields: String,
         @Query("filter") filter: String,
     ): Call<Attributes>
 
-    @GET("/api/programs")
+    @GET("/api/programs.json")
     fun getPrograms(
         @Query("paging") paging: Boolean,
         @Query("fields") fields: String,
         @Query("filter") filter: String,
     ): Call<Programs>
 
-    @GET("/api/organisationUnits")
+    @GET("/api/organisationUnits.json")
     fun getOrganisationUnits(
         @Query("paging") paging: Boolean,
         @Query("fields") fields: String,

--- a/app/src/main/java/org/dhis2/usescases/simprintsId/DownloadSimprintsIdAttributesUseCase.kt
+++ b/app/src/main/java/org/dhis2/usescases/simprintsId/DownloadSimprintsIdAttributesUseCase.kt
@@ -1,0 +1,40 @@
+package org.dhis2.usescases.simprintsId
+
+import org.dhis2.data.simprintsId.local.LocalSimprintsModuleIdMappingRepository
+import org.dhis2.data.simprintsId.local.LocalSimprintsProjectIdMappingRepository
+import org.dhis2.data.simprintsId.remote.RemoteSimprintsModuleIdMappingRepository
+import org.dhis2.data.simprintsId.remote.RemoteSimprintsProjectIdMappingRepository
+import javax.inject.Inject
+
+class DownloadSimprintsIdAttributesUseCase @Inject constructor(
+    private val remoteProjectIdMappingRepository: RemoteSimprintsProjectIdMappingRepository,
+    private val remoteModuleIdMappingRepository: RemoteSimprintsModuleIdMappingRepository,
+    private val localProjectIdMappingRepository: LocalSimprintsProjectIdMappingRepository,
+    private val localModuleIdMappingRepository: LocalSimprintsModuleIdMappingRepository,
+) {
+
+    fun execute(): Result<Unit> = runCatching {
+        getAndProcessData(
+            getter = remoteProjectIdMappingRepository::getProgramUidToProjectIdMap,
+            processor = localProjectIdMappingRepository::updateProgramUidToProjectIdMap,
+        )
+        getAndProcessData(
+            getter = remoteModuleIdMappingRepository::getOrgUnitUidToModuleIdMap,
+            processor = localModuleIdMappingRepository::updateOrgUnitUidToModuleIdMap,
+        )
+    }
+
+    private fun <T> getAndProcessData(
+        getter: () -> Result<T>,
+        processor: (T) -> Unit,
+    ) {
+        val data = getter()
+        data.getOrNull()
+            ?.let { processor(it) }
+            ?: throw (
+                data.exceptionOrNull() ?: IllegalStateException(
+                    "Simprints attributes mapping retrieval result error: neither value, nor exception",
+                )
+                )
+    }
+}

--- a/app/src/main/java/org/dhis2/usescases/simprintsId/GetSimprintsModuleIdUseCase.kt
+++ b/app/src/main/java/org/dhis2/usescases/simprintsId/GetSimprintsModuleIdUseCase.kt
@@ -1,0 +1,30 @@
+package org.dhis2.usescases.simprintsId
+
+import org.dhis2.data.simprintsId.local.LocalSimprintsModuleIdMappingRepository
+import org.hisp.dhis.android.core.D2
+import javax.inject.Inject
+
+class GetSimprintsModuleIdUseCase @Inject constructor(
+    private val localModuleIdMappingRepository: LocalSimprintsModuleIdMappingRepository,
+    private val d2: D2,
+) {
+
+    fun execute(orgUnitUid: String): String? {
+        // First, looking for this org unit
+        localModuleIdMappingRepository.getModuleIdOrNull(orgUnitUid)
+            ?.let { return it }
+        // If not found, looking for higher level org units
+        var higherLevelOrgUnitUid: String? = orgUnitUid
+        do {
+            higherLevelOrgUnitUid = getHigherLevelOrgUnitUidOrNull(higherLevelOrgUnitUid)
+            higherLevelOrgUnitUid?.run(localModuleIdMappingRepository::getModuleIdOrNull)
+                ?.let { return it }
+        } while (higherLevelOrgUnitUid != null)
+        // If none found
+        return null
+    }
+
+    private fun getHigherLevelOrgUnitUidOrNull(orgUnitUid: String?): String? =
+        d2.organisationUnitModule().organisationUnits().byUid().eq(orgUnitUid).blockingGet()
+            .map { it.parent()?.uid() }.firstOrNull()
+}

--- a/app/src/main/java/org/dhis2/usescases/simprintsId/GetSimprintsProjectIdUseCase.kt
+++ b/app/src/main/java/org/dhis2/usescases/simprintsId/GetSimprintsProjectIdUseCase.kt
@@ -1,0 +1,12 @@
+package org.dhis2.usescases.simprintsId
+
+import org.dhis2.data.simprintsId.local.LocalSimprintsProjectIdMappingRepository
+import javax.inject.Inject
+
+class GetSimprintsProjectIdUseCase @Inject constructor(
+    private val localProjectIdMappingRepository: LocalSimprintsProjectIdMappingRepository,
+) {
+
+    fun execute(programUid: String): String? =
+        localProjectIdMappingRepository.getProjectIdOrNull(programUid)
+}

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataModule.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/dashboardfragments/teidata/TEIDataModule.kt
@@ -20,6 +20,8 @@ import org.dhis2.data.forms.dataentry.SearchTEIRepository
 import org.dhis2.data.forms.dataentry.SearchTEIRepositoryImpl
 import org.dhis2.form.data.FormValueStore
 import org.dhis2.form.data.OptionsRepository
+import org.dhis2.usescases.simprintsId.GetSimprintsModuleIdUseCase
+import org.dhis2.usescases.simprintsId.GetSimprintsProjectIdUseCase
 import org.dhis2.usescases.teiDashboard.DashboardRepository
 import org.dhis2.usescases.teiDashboard.data.ProgramConfigurationRepository
 import org.dhis2.usescases.teiDashboard.domain.GetNewEventCreationTypeOptions
@@ -142,8 +144,14 @@ class TEIDataModule(
     @Provides
     fun provideTeiCardMapper(
         resourceManager: ResourceManager,
+        getSimprintsProjectIdUseCase: GetSimprintsProjectIdUseCase,
+        getSimprintsModuleIdUseCase: GetSimprintsModuleIdUseCase,
     ): TeiDashboardCardMapper {
-        return TeiDashboardCardMapper(resourceManager)
+        return TeiDashboardCardMapper(
+            resourceManager,
+            getSimprintsProjectIdUseCase,
+            getSimprintsModuleIdUseCase,
+        )
     }
 
     @Provides

--- a/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/mapper/TeiDashboardCardMapper.kt
+++ b/app/src/main/java/org/dhis2/usescases/teiDashboard/ui/mapper/TeiDashboardCardMapper.kt
@@ -12,6 +12,8 @@ import org.dhis2.R
 import org.dhis2.commons.data.tuples.Pair
 import org.dhis2.commons.date.toUi
 import org.dhis2.commons.resources.ResourceManager
+import org.dhis2.usescases.simprintsId.GetSimprintsModuleIdUseCase
+import org.dhis2.usescases.simprintsId.GetSimprintsProjectIdUseCase
 import org.dhis2.usescases.teiDashboard.DashboardProgramModel
 import org.dhis2.usescases.teiDashboard.ui.model.TeiCardUiModel
 import org.hisp.dhis.android.core.common.ValueType
@@ -28,6 +30,8 @@ import java.util.Date
 
 class TeiDashboardCardMapper(
     val resourceManager: ResourceManager,
+    private val getSimprintsProjectIdUseCase: GetSimprintsProjectIdUseCase,
+    private val getSimprintsModuleIdUseCase: GetSimprintsModuleIdUseCase,
 ) {
 
     fun map(
@@ -156,6 +160,15 @@ class TeiDashboardCardMapper(
                 )
             }
         }.also { list ->
+            // Prototype display-only value readouts for mapped Simprints-related attributes
+            addSimprintsData(
+                list,
+                simprintsProjectId = item.currentProgram?.uid()
+                    ?.run(getSimprintsProjectIdUseCase::execute),
+                simprintsModuleId = item.currentOrgUnit?.uid()
+                    ?.run(getSimprintsModuleIdUseCase::execute),
+            )
+        }.also { list ->
             if (item.enrollmentActivePrograms.isNotEmpty()) {
                 addEnrollPrograms(
                     list,
@@ -222,6 +235,29 @@ class TeiDashboardCardMapper(
                 isConstantItem = true,
             ),
         )
+    }
+
+    private fun addSimprintsData(
+        list: MutableList<AdditionalInfoItem>,
+        simprintsProjectId: String?,
+        simprintsModuleId: String?,
+    ) {
+        simprintsProjectId?.run {
+            list.add(
+                AdditionalInfoItem(
+                    key = "${resourceManager.getString(R.string.simprints_project_id)}:",
+                    value = this,
+                ),
+            )
+        }
+        simprintsModuleId?.run {
+            list.add(
+                AdditionalInfoItem(
+                    key = "${resourceManager.getString(R.string.simprints_module_id)}:",
+                    value = this,
+                ),
+            )
+        }
     }
 
     private fun List<Pair<TrackedEntityAttribute, TrackedEntityAttributeValue>>.filterAttributes() =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -717,6 +717,8 @@
     <string name="filters_title_event_status">Event status</string>
     <string name="filters_title_enrollment_status">Enrollment status</string>
     <string name="enrollment_date">Enrollment date</string>
+    <string name="simprints_project_id">Simprints Project ID</string>
+    <string name="simprints_module_id">Simprints Module ID</string>
     <string name="dataset_empty_list_can_create">There are no data. Click \"+\" to add new a new record</string>
     <string name="dataset_emtpy_list_can_not_create">There are no data. You don\'t have permission to add new records.</string>
     <string name="validation_rules_empty_description">No description or instruction provided</string>

--- a/app/src/test/java/org/dhis2/data/services/SyncPresenterTest.kt
+++ b/app/src/test/java/org/dhis2/data/services/SyncPresenterTest.kt
@@ -8,6 +8,7 @@ import org.dhis2.data.service.SyncRepository
 import org.dhis2.data.service.SyncResult
 import org.dhis2.data.service.SyncStatusController
 import org.dhis2.data.service.workManager.WorkManagerController
+import org.dhis2.usescases.simprintsId.DownloadSimprintsIdAttributesUseCase
 import org.dhis2.utils.analytics.AnalyticsHelper
 import org.hisp.dhis.android.core.D2
 import org.hisp.dhis.android.core.arch.call.BaseD2Progress
@@ -40,6 +41,7 @@ class SyncPresenterTest {
     private val analyticsHelper: AnalyticsHelper = mock()
     private val syncStatusController: SyncStatusController = mock()
     private val syncRepository: SyncRepository = mock()
+    private val downloadSimprintsIdAttributesUseCase: DownloadSimprintsIdAttributesUseCase = mock()
 
     @Before
     fun setUp() {
@@ -50,6 +52,7 @@ class SyncPresenterTest {
             analyticsHelper,
             syncStatusController,
             syncRepository,
+            downloadSimprintsIdAttributesUseCase,
         )
     }
 

--- a/app/src/test/java/org/dhis2/usescases/teiDashboard/ui/mapper/TEIDetailMapperTest.kt
+++ b/app/src/test/java/org/dhis2/usescases/teiDashboard/ui/mapper/TEIDetailMapperTest.kt
@@ -3,6 +3,8 @@ package org.dhis2.usescases.teiDashboard.ui.mapper
 import org.dhis2.R
 import org.dhis2.commons.data.tuples.Pair
 import org.dhis2.commons.resources.ResourceManager
+import org.dhis2.usescases.simprintsId.GetSimprintsModuleIdUseCase
+import org.dhis2.usescases.simprintsId.GetSimprintsProjectIdUseCase
 import org.dhis2.usescases.teiDashboard.DashboardProgramModel
 import org.hisp.dhis.android.core.common.State
 import org.hisp.dhis.android.core.enrollment.Enrollment
@@ -24,6 +26,8 @@ import org.mockito.kotlin.whenever
 class TEIDetailMapperTest {
 
     private val resourceManager: ResourceManager = mock()
+    private val getSimprintsProjectIdUseCase: GetSimprintsProjectIdUseCase = mock()
+    private val getSimprintsModuleIdUseCase: GetSimprintsModuleIdUseCase = mock()
     private lateinit var mapper: TeiDashboardCardMapper
 
     @Before
@@ -31,7 +35,11 @@ class TEIDetailMapperTest {
         whenever(resourceManager.getString(R.string.show_more)) doReturn "Show more"
         whenever(resourceManager.getString(R.string.show_less)) doReturn "Show less"
 
-        mapper = TeiDashboardCardMapper(resourceManager)
+        mapper = TeiDashboardCardMapper(
+            resourceManager,
+            getSimprintsProjectIdUseCase,
+            getSimprintsModuleIdUseCase,
+        )
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -186,6 +186,7 @@ analytics-sentry = { group = "io.sentry", name = "sentry-android", version.ref =
 security-rootbeer = { group = "com.scottyab", name = "rootbeer-lib", version.ref = "root" }
 security-openId = { group = "net.openid", name = "appauth", version.ref = "openid" }
 security-conscrypt = { group = "org.conscrypt", name = "conscrypt-android", version.ref = "conscrypt" }
+security-crypto = { group = "androidx.security", name = "security-crypto", version = "1.1.0-alpha06" }
 test-junit = { group = "junit", name = "junit", version.ref = "junit" }
 test-archCoreTesting = { group = "androidx.arch.core", name = "core-testing", version = "2.2.0" }
 test-testCore = { group = "androidx.test", name = "core", version.ref = "androidx_test" }


### PR DESCRIPTION
ProjectID and ModuleID custom attributes down-synced from the DHIS2 back-end instance to this Android app, to be used with Simprints ID at the next stages of this prototype. Their values are displayed in the TEI (beneficiary) profile when available.

See more detailed description in the [README.md](https://github.com/Simprints/SimTracker/blob/d1f48a9b278ad6635fb1d59faa8beb80a68ba1e3/README.md) updated within these changes.

Example of a profile of a TEI enrolled in a program with `ChildProgrammeProjectId` ProjectID and belonging to an organisation unit that's part of Bo (ModuleID of which is `BoModuleId`):

<img src="https://github.com/Simprints/SimTracker/assets/6236091/f24d2717-e8e4-44e3-8719-aa856c5a66aa" width="400">