### PR TITLE
Simprints-specific application IDs in build flavors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,21 +166,21 @@ android {
 
     productFlavors {
         create("dhis") {
-            applicationId = "com.dhis2"
+            applicationId = "com.simprints.dhis2"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
             versionName = libs.versions.vName.get()
         }
 
         create("dhisPlayServices") {
-            applicationId = "com.dhis2"
+            applicationId = "com.simprints.dhis2"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
             versionName = libs.versions.vName.get()
         }
 
         create("dhisUITesting") {
-            applicationId = "com.dhis2"
+            applicationId = "com.simprints.dhis2"
             dimension = "default"
             versionCode = libs.versions.vCode.get().toInt()
             versionName = libs.versions.vName.get()


### PR DESCRIPTION
Simprints-specific application ID in default config was overridden with upstream-specific ones in build flavor configs, which was still causing conflicts between upstream and fork app installations.